### PR TITLE
Fixed Bin Edges and minor changes

### DIFF
--- a/te-datainit.cpp
+++ b/te-datainit.cpp
@@ -471,6 +471,44 @@ rawdata discretize(double in, double min, double max, unsigned int nr_bins)
   return rawdata(xint);
 };
 
+// Orlandi: Adding option for predefined binning limits
+rawdata** generate_discretized_version_of_time_series(double** in, unsigned int size, long nr_samples, std::vector<double> binEdges)
+{
+  rawdata** xout;
+  xout = new rawdata*[size];
+  for(unsigned int ii=0; ii<size; ii++)
+  {
+    xout[ii] = new rawdata[nr_samples];
+    discretize(in[ii], xout[ii], nr_samples, binEdges);
+  }  
+  return xout;
+};
+
+void discretize(double* in, rawdata* out, long nr_samples, std::vector<double> binEdges)
+{
+  int xint;
+  for (unsigned long t=0; t<nr_samples; t++)
+    out[t] = discretize(in[t], binEdges);
+};
+// For now the bottom and top edges are doing nothing, they act like (-inf and inf)
+rawdata discretize(double in, std::vector<double> binEdges)
+{
+  // By default set it to the top bin
+  int xint = binEdges.size()-1;
+
+  // Correct to the right bin
+  for(std::vector<double>::size_type i = 1; i != binEdges.size(); i++)
+  {
+      if(in < binEdges[i])
+      {
+        xint = i-1;
+        break;
+      }
+  }
+  assert((xint>=0)&&(rawdata(xint)<binEdges.size())); // ...just to be sure...*/
+  return rawdata(xint);
+};
+
 // #ifdef ENABLE_ADAPTIVE_BINNING_AT_COMPILE_TIME 
 // void discretize2accordingtoStd(double* in, rawdata* out)
 // {

--- a/te-datainit.h
+++ b/te-datainit.h
@@ -71,6 +71,11 @@ void discretize(double* in, rawdata* out, double min, double max, long nr_sample
 rawdata discretize(double in, double min, double max, unsigned int nr_bins);
 // void discretize2accordingtoStd(double* in, rawdata* out);
 
+// Orlandi: Adding option for predefined binning limits
+rawdata** generate_discretized_version_of_time_series(double** in, unsigned int size, long nr_samples, std::vector<double> binEdges);
+void discretize(double* in, rawdata* out, long nr_samples, std::vector<double> binEdges);
+rawdata discretize(double in, std::vector<double> binEdges);
+
 void apply_high_pass_filter_to_time_series(double** time_series, unsigned int size, long nr_samples);
 void apply_high_pass_filter_to_time_series(double* time_series, long nr_samples);
 

--- a/te-datainit.h
+++ b/te-datainit.h
@@ -42,7 +42,7 @@
 // set output stream depending on wether SimKernel's sim.h is included
 // (see also te-datainit.cpp)
 // Unit tests will only work without SimKernel!
-#include "../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 
 #undef IOSTREAMD
 #ifdef SIM_IO_H

--- a/transferentropy-sim/Rakefile
+++ b/transferentropy-sim/Rakefile
@@ -31,7 +31,7 @@ maketemp_path = "./maketemp"
 enable_mpi = false
 
 
-ld_flags_basic = "-lgslcblas -lgsl -lm -lyaml-cpp -L."
+ld_flags_basic = "-lgsl -lgslcblas -lm -lyaml-cpp -L."
 ld_flags_flann = "-lflann_cpp"
 obj_base = %W{ #{maketemp_path}/olav.o #{maketemp_path}/te-datainit.o #{maketemp_path}/miniprofiler.o #{maketemp_path}/expression.o #{maketemp_path}/expression_basic.o #{maketemp_path}/expression_sim.o #{maketemp_path}/expression_extra.o #{maketemp_path}/expression_parser.o #{maketemp_path}/sim_io_manager.o #{maketemp_path}/sim_io.o #{maketemp_path}/sim_signals.o #{maketemp_path}/sim.o }
 
@@ -41,12 +41,12 @@ util_sources = %W{ ../olav.cpp ../te-datainit.cpp ../multidimarray.cpp ../multip
 
 if enable_mpi
   cc = "mpic++"
-  cflags = "-DSIM_MPI -O3"
+  cflags = "-DSIM_MPI -O3 -I" << sim_path
   sim_sources = sim_sources << " #{sim_path}/sim_mpi.cpp"
   obj = ["#{maketemp_path}/sim_mpi.o"] << obj_base
 else
   cc = "g++"
-  cflags = "-O3"
+  cflags = "-O3 -I" << sim_path
   # cflags = " -g" # to enable debugging later
   obj = obj_base
 end

--- a/transferentropy-sim/granger.cpp
+++ b/transferentropy-sim/granger.cpp
@@ -31,7 +31,7 @@
 #include <gsl/gsl_vector_double.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 
 #undef NORMALIZE_GRANGER_CAUSALITY_ESTIMATE

--- a/transferentropy-sim/mi.cpp
+++ b/transferentropy-sim/mi.cpp
@@ -30,7 +30,7 @@
 #include <gsl/gsl_vector.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 #include "../multidimarray.h"
 

--- a/transferentropy-sim/te-binless-Frenzel.cpp
+++ b/transferentropy-sim/te-binless-Frenzel.cpp
@@ -29,7 +29,7 @@
 #include <gsl/gsl_sf_psi.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 
 #include <flann/flann.hpp>

--- a/transferentropy-sim/te-binless-Kraskov.cpp
+++ b/transferentropy-sim/te-binless-Kraskov.cpp
@@ -29,7 +29,7 @@
 #include <gsl/gsl_sf_psi.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 
 #include <flann/flann.hpp>

--- a/transferentropy-sim/te-binless-Leonenko.cpp
+++ b/transferentropy-sim/te-binless-Leonenko.cpp
@@ -28,7 +28,7 @@
 #include <gsl/gsl_vector_double.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 
 #define ENABLE_FLANN_AT_COMPILE_TIME

--- a/transferentropy-sim/te-extended.cpp
+++ b/transferentropy-sim/te-extended.cpp
@@ -31,7 +31,7 @@
 #include <gsl/gsl_vector.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 #include "../multidimarray.h"
 

--- a/transferentropy-sim/te-symbolic.cpp
+++ b/transferentropy-sim/te-symbolic.cpp
@@ -34,7 +34,7 @@
 #include <gsl/gsl_permutation.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 #include "../multipermutation.h"
 

--- a/transferentropy-sim/xcorr.cpp
+++ b/transferentropy-sim/xcorr.cpp
@@ -28,7 +28,7 @@
 // #include <gsl/gsl_vector.h>
 
 #include "../olav.h"
-#include "../../../Sonstiges/SimKernel/sim_main.h"
+#include <sim_main.h>
 #include "../te-datainit.h"
 
 // #ifndef INLINE


### PR DESCRIPTION
2 minor additions to the project:
1. Ability to specify fixed bin edges in the control file.
   The entry in the control file is as follows:
   bins = 2;
   binEdges = {-1.0, 0.1, 1.0};
   
   The size of binEdges has to be bins+1 and must be in ascending order. For now the bottom and top limits are not used, they are the same as -inf and inf. If binEdges exists in the control file it replaces the current method of estimating the bin edges based on the minimum and maximum of the distribution.
2. Modified Rakefile to add the SimKernel as an include -I to avoid the use of so many relative paths in all the other files. Now the only relative path associated to the SimKernel should be in the Rakefile.
