### PR TITLE
Bug fix on binEdges routine

### DIFF
--- a/te-datainit.cpp
+++ b/te-datainit.cpp
@@ -501,22 +501,23 @@ void discretize(double* in, rawdata* out, long nr_samples, std::vector<double> b
   for (unsigned long t=0; t<nr_samples; t++)
     out[t] = discretize(in[t], binEdges);
 };
+
 // For now the bottom and top edges are doing nothing, they act like (-inf and inf)
 rawdata discretize(double in, std::vector<double> binEdges)
 {
   // By default set it to the top bin
-  int xint = binEdges.size()-1;
+  int xint = binEdges.size()-2;
 
   // Correct to the right bin
   for(std::vector<double>::size_type i = 1; i != binEdges.size(); i++)
   {
-      if(in < binEdges[i])
-      {
-        xint = i-1;
-        break;
-      }
+    if(in < binEdges[i])
+    {
+      xint = i-1;
+      break;
+    }
   }
-  assert((xint>=0)&&(rawdata(xint)<binEdges.size())); // ...just to be sure...*/
+  assert((xint>=0)&&(rawdata(xint)<(binEdges.size()-1))); // ...just to be sure...*/
   return rawdata(xint);
 };
 

--- a/transferentropy-sim/te-extended.cpp
+++ b/transferentropy-sim/te-extended.cpp
@@ -187,15 +187,14 @@ public:
     sim.get("binEdges", binEdges, 0);
     if(binEdges.size() > 1)
     {
-        double tmpdiff;
-        // Check that the bin edges are increasing in size
-        for(std::vector<double>::iterator iteratorBinEdges = binEdges.begin()+1; iteratorBinEdges != binEdges.end(); iteratorBinEdges++)
-            assert(*iteratorBinEdges-*(iteratorBinEdges-1) > 0.);
-        assert(binEdges.size()-1 == bins);
-        binEdgesSet = true;
+      // Check that the bin edges are increasing in size
+      for(std::vector<double>::iterator iteratorBinEdges = binEdges.begin()+1; iteratorBinEdges != binEdges.end(); iteratorBinEdges++)
+        assert(*iteratorBinEdges-*(iteratorBinEdges-1) > 0.);
+      assert(binEdges.size()-1 == bins);
+      binEdgesSet = true;
     }
     else
-        binEdgesSet = false;
+      binEdgesSet = false;
 
     sim.get("noise",std_noise,-1.);
     sim.get("appliedscaling",input_scaling,1.);
@@ -418,9 +417,9 @@ public:
       sim.io <<"discretizing local time series..."<<Endl;
       // Orlandi: Adding option for predefined binning limits
       if(!binEdgesSet)
-          xdata = generate_discretized_version_of_time_series(xdatadouble, size, samples, bins);
+        xdata = generate_discretized_version_of_time_series(xdatadouble, size, samples, bins);
       else
-          xdata = generate_discretized_version_of_time_series(xdatadouble, size, samples, binEdges);
+        xdata = generate_discretized_version_of_time_series(xdatadouble, size, samples, binEdges);
       // and, since double version of time series is not used any more...
       if(xdatadouble!=NULL) free_time_series_memory(xdatadouble, size);
       sim.io <<" -> done."<<Endl;


### PR DESCRIPTION
Fixed a bug that was causing an overflow when the biggest bin edge was smaller than the maximum value of the signal.

Also fixed the indentation.
